### PR TITLE
feat: Use native `fetch()` instead of axios

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 - 2023 Fabian Meyer
+Copyright (c) 2016 - 2024 Fabian Meyer
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,3 @@
-import axios from 'axios'
-
 /**
  * URL of the verification endpoint.
  */
@@ -85,11 +83,17 @@ function createInstance (config?: RecaptchaVerifierConfig): RecaptchaVerifier {
       response,
       remoteip: remoteAddress ?? ''
     }).toString()
-    const { data } = await axios.post(VERIFY_ENDPOINT, postBody, {
+    const postResponse = await fetch(VERIFY_ENDPOINT, {
+      method: 'post',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded'
-      }
+      },
+      body: postBody
     })
+    const data = await postResponse.json()
+    if (data == null || typeof data !== 'object' || !('success' in data) || typeof data.success !== 'boolean') {
+      throw new Error('unexpected response')
+    }
     return data.success
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,19 +8,16 @@
       "name": "recaptcha-promise",
       "version": "3.0.2",
       "license": "MIT",
-      "dependencies": {
-        "axios": "^1.6.2"
-      },
       "devDependencies": {
         "@meyfa/eslint-config": "6.0.0",
         "@types/mocha": "10.0.7",
         "@types/node": "20.14.11",
-        "axios-mock-adapter": "1.21.5",
         "c8": "10.1.2",
         "eslint": "8.57.0",
         "mocha": "10.6.0",
         "ts-node": "10.9.2",
-        "typescript": "5.5.3"
+        "typescript": "5.5.3",
+        "undici": "6.19.2"
       },
       "engines": {
         "node": ">=18.16.1"
@@ -1095,11 +1092,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -1110,29 +1102,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/axios": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
-      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
-      "dependencies": {
-        "follow-redirects": "^1.15.0",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/axios-mock-adapter": {
-      "version": "1.21.5",
-      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.21.5.tgz",
-      "integrity": "sha512-5NI1V/VK+8+JeTF8niqOowuysA4b8mGzdlMN/QnTnoXbYh4HZSNiopsDclN2g/m85+G++IrEtUdZaQ3GnaMsSA==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "is-buffer": "^2.0.5"
-      },
-      "peerDependencies": {
-        "axios": ">= 0.17.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1485,17 +1454,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/comment-parser": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
@@ -1617,14 +1575,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/diff": {
@@ -2504,25 +2454,6 @@
       "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
       "dev": true
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -2546,19 +2477,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/fs.realpath": {
@@ -3014,29 +2932,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-buffer": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/is-builtin-module": {
@@ -3523,25 +3418,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/min-indent": {
@@ -4038,11 +3914,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.3.0",
@@ -4984,6 +4855,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.2.tgz",
+      "integrity": "sha512-JfjKqIauur3Q6biAtHJ564e3bWa8VvT+7cSiOJHFbX4Erv6CLGDpg8z+Fmg/1OI/47RA+GI2QZaF48SSaLvyBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -32,18 +32,15 @@
   "engines": {
     "node": ">=18.16.1"
   },
-  "dependencies": {
-    "axios": "^1.6.2"
-  },
   "devDependencies": {
     "@meyfa/eslint-config": "6.0.0",
     "@types/mocha": "10.0.7",
     "@types/node": "20.14.11",
-    "axios-mock-adapter": "1.21.5",
     "c8": "10.1.2",
     "eslint": "8.57.0",
     "mocha": "10.6.0",
     "ts-node": "10.9.2",
-    "typescript": "5.5.3"
+    "typescript": "5.5.3",
+    "undici": "6.19.2"
   }
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,19 +1,21 @@
-import assert from 'node:assert'
-import axios from 'axios'
-import MockAdapter from 'axios-mock-adapter'
-
 import recaptcha from '../index.js'
+import assert from 'node:assert'
+import { getGlobalDispatcher, MockAgent, MockPool, setGlobalDispatcher } from 'undici'
 
 describe('main export', function () {
-  const mock = new MockAdapter(axios, { onNoMatch: 'throwException' })
+  const apiPath = '/recaptcha/api/siteverify'
+  const matchAny = (): boolean => true
 
-  afterEach(function () {
-    mock.reset()
-  })
+  function createMockPool (): MockPool {
+    const mockAgent = new MockAgent()
+    mockAgent.disableNetConnect()
+    setGlobalDispatcher(mockAgent)
 
-  after(function () {
-    mock.restore()
-  })
+    return mockAgent.get('https://www.google.com')
+  }
+
+  const oldGlobalDispatcher = getGlobalDispatcher()
+  afterEach(() => setGlobalDispatcher(oldGlobalDispatcher))
 
   describe('#verify()', function () {
     it('is aliased to the main export', function () {
@@ -22,43 +24,59 @@ describe('main export', function () {
     })
 
     it('rejects if unconfigured, does not perform requests', async function () {
+      const mockPool = createMockPool()
+      let callCount = 0
+      mockPool.intercept({ path: matchAny, method: matchAny }).reply(500, () => {
+        ++callCount
+      })
       // @ts-expect-error - intentionally pass undefined
       recaptcha.init({ secret: undefined }) // reset secret
       await assert.rejects(async () => await recaptcha.verify('foo'))
-      assert.strictEqual(mock.history.post.length, 0)
+      assert.strictEqual(callCount, 0)
     })
 
     it('performs a request with correct body if configured', async function () {
+      const mockPool = createMockPool()
       recaptcha.init({ secret: 'test-secret' })
-      mock.onAny().replyOnce(config => {
-        assert.strictEqual(config.url, 'https://www.google.com/recaptcha/api/siteverify')
-        assert.strictEqual(config.method, 'post')
-        assert.strictEqual(config.data, 'secret=test-secret&response=foo&remoteip=bar')
-        const contentType = config.headers != null ? config.headers['Content-Type'] : undefined
+      let callCount = 0
+      mockPool.intercept({ path: apiPath, method: 'POST' }).reply(200, (config) => {
+        ++callCount
+        assert.strictEqual(config.path, '/recaptcha/api/siteverify')
+        assert.strictEqual(config.method, 'POST')
+        assert.strictEqual(config.body?.toString(), 'secret=test-secret&response=foo&remoteip=bar')
+        const contentType = config.headers != null ? new Headers(config.headers).get('Content-Type') : undefined
         assert.strictEqual(contentType, 'application/x-www-form-urlencoded')
-        return [200, { success: true }]
+        return { success: true }
       })
       await recaptcha.verify('foo', 'bar')
-      assert.strictEqual(mock.history.post.length, 1)
+      assert.strictEqual(callCount, 1)
     })
 
     it('does not pass remoteip if left out', async function () {
+      const mockPool = createMockPool()
       recaptcha.init({ secret: 'test-secret' })
-      mock.onAny().replyOnce(config => {
-        assert.strictEqual(config.data, 'secret=test-secret&response=foo&remoteip=')
-        return [200, { success: true }]
+      let callCount = 0
+      mockPool.intercept({ path: apiPath, method: 'POST' }).reply(200, (config) => {
+        ++callCount
+        assert.strictEqual(config.body?.toString(), 'secret=test-secret&response=foo&remoteip=')
+        return { success: true }
       })
       await recaptcha.verify('foo')
-      assert.strictEqual(mock.history.post.length, 1)
+      assert.strictEqual(callCount, 1)
     })
 
     it('resolves with success value', async function () {
+      const mockPool = createMockPool()
       recaptcha.init({ secret: 'test-secret' })
       // case 1
-      mock.onAny().replyOnce(200, { success: true })
+      mockPool.intercept({ path: apiPath, method: 'POST' }).reply(200, (config) => {
+        return { success: true }
+      })
       assert.strictEqual(await recaptcha.verify('foo'), true)
       // case 2
-      mock.onAny().replyOnce(200, { success: false })
+      mockPool.intercept({ path: apiPath, method: 'POST' }).reply(200, (config) => {
+        return { success: false }
+      })
       assert.strictEqual(await recaptcha.verify('foo'), false)
     })
   })
@@ -78,27 +96,28 @@ describe('main export', function () {
     })
 
     it('does not distinguish between secret, secretKey, secret_key', async function () {
+      const mockPool = createMockPool()
       // case 1
       recaptcha.init({ secret: 'secret' })
-      mock.onAny().replyOnce(config => {
-        assert.strictEqual(config.data, 'secret=secret&response=foo&remoteip=bar')
-        return [200, { success: true }]
+      mockPool.intercept({ path: apiPath, method: 'POST' }).reply(200, (config) => {
+        assert.strictEqual(config.body?.toString(), 'secret=secret&response=foo&remoteip=bar')
+        return { success: true }
       })
       await recaptcha.verify('foo', 'bar')
 
       // case 2
       recaptcha.init({ secretKey: 'secretKey' } as any)
-      mock.onAny().replyOnce(config => {
-        assert.strictEqual(config.data, 'secret=secretKey&response=foo&remoteip=bar')
-        return [200, { success: true }]
+      mockPool.intercept({ path: apiPath, method: 'POST' }).reply(200, (config) => {
+        assert.strictEqual(config.body?.toString(), 'secret=secretKey&response=foo&remoteip=bar')
+        return { success: true }
       })
       await recaptcha.verify('foo', 'bar')
 
       // case 2
       recaptcha.init({ secret_key: 'secret_key' } as any)
-      mock.onAny().replyOnce(config => {
-        assert.strictEqual(config.data, 'secret=secret_key&response=foo&remoteip=bar')
-        return [200, { success: true }]
+      mockPool.intercept({ path: apiPath, method: 'POST' }).reply(200, (config) => {
+        assert.strictEqual(config.body?.toString(), 'secret=secret_key&response=foo&remoteip=bar')
+        return { success: true }
       })
       await recaptcha.verify('foo', 'bar')
     })
@@ -124,33 +143,43 @@ describe('main export', function () {
       })
 
       it('rejects if unconfigured, does not perform requests', async function () {
+        const mockPool = createMockPool()
+        let callCount = 0
+        mockPool.intercept({ path: matchAny, method: matchAny }).reply(500, () => {
+          ++callCount
+        })
         const obj = recaptcha.create()
         await assert.rejects(async () => await obj.verify('foo'))
-        assert.strictEqual(mock.history.post.length, 0)
+        assert.strictEqual(callCount, 0)
       })
 
       it('is independent between instances', async function () {
+        const mockPool = createMockPool()
+
         // @ts-expect-error - intentionally pass undefined
         recaptcha.init({ secret: undefined }) // reset secret
         const instance1 = recaptcha.create({ secret: 'secret1' })
         const instance2 = recaptcha.create({ secret: 'secret2' })
 
         // case 1
-        mock.onAny().replyOnce(config => {
-          assert.strictEqual(config.data, 'secret=secret1&response=foo1&remoteip=bar1')
-          return [200, { success: true }]
+        let callCount1 = 0
+        mockPool.intercept({ path: apiPath, method: 'POST' }).reply(200, (config) => {
+          ++callCount1
+          assert.strictEqual(config.body?.toString(), 'secret=secret1&response=foo1&remoteip=bar1')
+          return { success: true }
         })
         await instance1.verify('foo1', 'bar1')
-        assert.strictEqual(mock.history.post.length, 1)
+        assert.strictEqual(callCount1, 1)
 
         // case 2
-        mock.reset()
-        mock.onAny().replyOnce(config => {
-          assert.strictEqual(config.data, 'secret=secret2&response=foo2&remoteip=bar2')
-          return [200, { success: true }]
+        let callCount2 = 0
+        mockPool.intercept({ path: apiPath, method: 'POST' }).reply(200, (config) => {
+          ++callCount2
+          assert.strictEqual(config.body?.toString(), 'secret=secret2&response=foo2&remoteip=bar2')
+          return { success: true }
         })
         await instance2.verify('foo2', 'bar2')
-        assert.strictEqual(mock.history.post.length, 1)
+        assert.strictEqual(callCount2, 1)
       })
     })
 
@@ -171,13 +200,17 @@ describe('main export', function () {
       })
 
       it('allows re-configuration', async function () {
+        const mockPool = createMockPool()
         const obj = recaptcha.create()
         obj.init({ secret: 'test-secret' })
-        mock.onAny().replyOnce(config => {
-          assert.strictEqual(config.data, 'secret=test-secret&response=foo&remoteip=bar')
-          return [200, { success: true }]
+        let callCount = 0
+        mockPool.intercept({ path: apiPath, method: 'POST' }).reply(200, (config) => {
+          ++callCount
+          assert.strictEqual(config.body?.toString(), 'secret=test-secret&response=foo&remoteip=bar')
+          return { success: true }
         })
         await obj.verify('foo', 'bar')
+        assert.strictEqual(callCount, 1)
       })
     })
   })


### PR DESCRIPTION
Fetch is available in Node.js 18 and later, and allows us to remove the only production dependency of this package with a minimal code change. Tests, however, need to be largely rewritten using Node.js's undici to mock global fetch.