### PR TITLE
fix: Make commonjs type explicit in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "recaptcha-promise",
   "version": "3.1.0",
   "description": "Node module for promise-based ReCAPTCHA verification",
+  "type": "commonjs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [


### PR DESCRIPTION
From https://nodejs.org/api/modules.html:

> Package authors should include the "type" field, even in packages
> where all sources are CommonJS. Being explicit about the type of the
> package will make things easier for build tools and loaders to
> determine how the files in the package should be interpreted.